### PR TITLE
fix: use nightly toolchain for container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@
 # https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
 
 # Builder stage - compile just-mcp from source
-FROM --platform=${BUILDPLATFORM} rust:1.82-alpine AS builder
+# Need nightly for edition2024 support
+FROM --platform=${BUILDPLATFORM} rustlang/rust:nightly-alpine AS builder
 
 # Install build dependencies
 # Note: musl provides static linking by default, no need for separate static libs

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 
 # Builder stage - compile just-mcp from source
 # Need nightly for edition2024 support
-FROM --platform=${BUILDPLATFORM} rustlang/rust:nightly-alpine AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/rustlang/rust:nightly-alpine AS builder
 
 # Install build dependencies
 # Note: musl provides static linking by default, no need for separate static libs


### PR DESCRIPTION
## Summary
- switch container builder to nightly alpine image because edition2024 requires nightly cargo
- document why nightly is required so future updates keep parity