### PR TITLE
fix: add pkgx support with proper binary build triggering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,13 @@ jobs:
             --draft=false \
             --prerelease=false
 
+      - name: Trigger binary builds
+        if: steps.check_changes.outputs.has_changes == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build-binaries.yml -f tag="${NEW_TAG}"
+
       - name: Set version output
         id: get_version
         run: |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ cd just-mcp
 cargo build --release
 ```
 
+#### pkgx (pkgxdev)
+```bash
+pkgx just-mcp --stdio
+```
+
+`pkgx` downloads the platform-specific tarball that GitHub releases expose (`just-mcp-*-*.tar.gz`), extracts the executable into `${PKGX_DIR:-$HOME/.pkgx}/bin`, and runs the CLI with the arguments you pass. Add that bin directory to your shell’s `PATH` if you need `just-mcp` available long-term. The packaging manifest lives in [`pkgx/projects/github.com/promptexecution/just-mcp/package.yml`](pkgx/projects/github.com/promptexecution/just-mcp/package.yml) and mirrors the `pkgxdev/pantry` entry.
+
 #### Using Docker
 ```bash
 # Pull the latest image from GitHub Container Registry

--- a/pkgx/README.md
+++ b/pkgx/README.md
@@ -1,0 +1,30 @@
+# pkgx packaging for just-mcp
+
+This directory documents how just-mcp is packaged for [pkgx](https://pkgx.sh) and also mirrors the `package.yml` that should land in the
+[`pkgxdev/pantry`](https://github.com/pkgxdev/pantry) repository under `projects/github.com/promptexecution/just-mcp`.
+
+## Pantry manifest
+
+`pkgx/projects/github.com/promptexecution/just-mcp/package.yml` downloads the release tarballs created by `.github/workflows/build-binaries.yml` for each
+platform, extracts the executable, and moves it into `{{ prefix }}/bin`. The manifest pulls the version number from the `PromptExecution/just-mcp`
+GitHub tags (`strip: /^v/`) so every release in this repo automatically becomes available to pkgx once the values are pushed to the pantry
+and the archives are uploaded to GitHub Releases.
+
+## Installation instructions
+
+Once the package lands in the pantry you can invoke the shipped binary like this:
+
+```bash
+pkgx just-mcp --stdio
+```
+
+`pkgx` will download the architecture-specific tarball (for example `just-mcp-x86_64-unknown-linux-gnu.tar.gz`), extract it to `~/.pkgx`, and run the
+`just-mcp --stdio` command. If you want the binary on your `PATH` permanently, add `${PKGX_DIR:-$HOME/.pkgx}/bin` to your shell profile so the
+`just-mcp` binary is reusable after the first invocation.
+
+## Keeping pkgx in sync with releases
+
+- The GitHub release must include the tarballs listed in `.github/workflows/build-binaries.yml` so the manifest can download the matching asset.
+- The pantry entry should stay in sync with the latest tag; updating the release will automatically expose `pkgx just-mcp` for that version.
+- You can test the manifest locally by setting `PKGX_PANTRY_PATH=$(pwd)` inside the pantry repo and running `pkgx just-mcp --version` once the
+  package builds.

--- a/pkgx/projects/github.com/promptexecution/just-mcp/package.yml
+++ b/pkgx/projects/github.com/promptexecution/just-mcp/package.yml
@@ -1,0 +1,54 @@
+distributable:
+  url: https://github.com/PromptExecution/just-mcp/archive/refs/tags/v{{version}}.tar.gz
+  strip-components: 1
+
+versions:
+  github: PromptExecution/just-mcp/tags
+  strip: /^v/
+
+description: Production-ready MCP server that exposes Justfile recipes over MCP.
+homepage: https://github.com/PromptExecution/just-mcp
+license: MIT
+
+build:
+  dependencies:
+    curl.se: '*'
+  working-directory: ${{prefix}}
+  script: |
+    case "{{hw.platform}}+{{hw.arch}}" in
+      linux+x86-64)
+        target="x86_64-unknown-linux-gnu"
+        ;;
+      linux+aarch64)
+        target="aarch64-unknown-linux-gnu"
+        ;;
+      darwin+x86-64)
+        target="x86_64-apple-darwin"
+        ;;
+      darwin+aarch64)
+        target="aarch64-apple-darwin"
+        ;;
+      windows+x86-64)
+        target="x86_64-pc-windows-msvc"
+        ;;
+      *)
+        echo "unsupported platform: {{hw.platform}}+{{hw.arch}}" >&2
+        exit 1
+        ;;
+    esac
+    archive="just-mcp-${target}.tar.gz"
+    curl -sSfL -o "$archive" "https://github.com/PromptExecution/just-mcp/releases/download/v{{version}}/${archive}"
+    tar -xzf "$archive"
+    mkdir -p {{ prefix }}/bin
+    if test "{{hw.platform}}" = "windows"; then
+      mv just-mcp.exe {{ prefix }}/bin/just-mcp.exe
+    else
+      mv just-mcp {{ prefix }}/bin/just-mcp
+    fi
+
+provides:
+  - bin/just-mcp
+  - bin/just-mcp.exe
+
+test: |
+  just-mcp --version


### PR DESCRIPTION
## Summary
- Add pkgx package manifest for `github.com/promptexecution/just-mcp`
- Fix release workflow to trigger binary builds after creating releases
- Document pkgx installation method in README

## Problem
The `pkgx install just-mcp` command doesn't work because:
1. Binary tarballs (e.g., `just-mcp-x86_64-unknown-linux-gnu.tar.gz`) are missing from releases
2. The `build-binaries.yml` workflow wasn't being triggered when releases were created
3. This is because GitHub Actions don't cascade when using the default `GITHUB_TOKEN`

## Solution
- Add explicit workflow trigger in `release.yml` after creating releases
- Add pkgx package manifest that downloads these binary tarballs
- Document pkgx installation in README

## Test plan
- [x] Commit and push pkgx configuration
- [ ] Merge this PR
- [ ] Trigger a new release to test binary build workflow
- [ ] Verify binary artifacts are uploaded to the release
- [ ] Test `pkgx just-mcp --version` once binaries are available