### PR TITLE
chore: add local wrkflw recipes

### DIFF
--- a/.b00tignore
+++ b/.b00tignore
@@ -1,0 +1,2 @@
+# b00t session files
+_b00t_.toml

--- a/justfile
+++ b/justfile
@@ -59,3 +59,13 @@ install-claude-mcp:
 	# cargo install --git https://github.com/PromptExecution/cratedocs-mcp --locked
 	claude mcp add fetch-url-as-markdown -- npx -y @upstash/fetch-url-as-markdown
 	claude mcp add rust-crate-doc -- cratedocs stdio --debug
+
+# ── wrkflw — local CI gate ──────────────────────────────────────────────────
+ci-validate:
+    wrkflw validate .github/workflows/ci.yml
+
+ci-local:
+    wrkflw run --runtime emulation .github/workflows/ci.yml
+
+ci-watch:
+    wrkflw watch .github/workflows/ci.yml


### PR DESCRIPTION
## Summary

Adds local wrkflw helper recipes to the justfile and ignores b00t session files.

## Validation

- `just -l` exited 0 and listed `ci-validate`, `ci-local`, and `ci-watch`.